### PR TITLE
Support Argfiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -90,10 +90,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users",
+ "winapi",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
+name = "getrandom"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
 
 [[package]]
 name = "hashbrown"
@@ -207,6 +238,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b033d837a7cf162d7993aded9304e30a83213c648b6e389db233191f891e5c2b"
+dependencies = [
+ "getrandom",
+ "redox_syscall",
+ "thiserror",
+]
+
+[[package]]
+name = "shellexpand"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ccc8076840c4da029af4f87e4e8daeb0fca6b87bbb02e10cb60b791450e11e4"
+dependencies = [
+ "dirs",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -230,7 +290,9 @@ dependencies = [
  "argfile",
  "clap",
  "ctrlc",
+ "dirs",
  "dunce",
+ "shellexpand",
 ]
 
 [[package]]
@@ -249,6 +311,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
+name = "thiserror"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5f6586b7f764adc0231f4c79be7b920e766bb2f3e51b3661cdb263828f19994"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12bafc5b54507e0149cdf1b145a5d80ab80a90bcd9275df43d4fff68460f6c21"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +341,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 3
 
 [[package]]
+name = "argfile"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f3a889586e8b0753fd320a319e713b8ef6a2693259604db10eca22bc92e8810"
+dependencies = [
+ "os_str_bytes",
+]
+
+[[package]]
 name = "atty"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -81,6 +90,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,6 +133,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "nix"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -139,6 +160,9 @@ name = "os_str_bytes"
 version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -203,8 +227,10 @@ dependencies = [
 name = "tenv"
 version = "0.2.0"
 dependencies = [
+ "argfile",
  "clap",
  "ctrlc",
+ "dunce",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,4 +15,6 @@ exclude = ["/.github"]
 argfile = "0.1.4"
 clap = { version = "3.2.13", features = ["derive"] }
 ctrlc = "3.2.2"
+dirs = "4.0.0"
 dunce = "1.0.2"
+shellexpand = "2.1.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,5 +12,7 @@ exclude = ["/.github"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+argfile = "0.1.4"
 clap = { version = "3.2.13", features = ["derive"] }
 ctrlc = "3.2.2"
+dunce = "1.0.2"

--- a/README.md
+++ b/README.md
@@ -9,6 +9,20 @@ Install from source
 ```
 cargo install --path .
 ```
+
+## Arg Files
+Supports `argfile`s. see [example.tenv](./example.tenv) for an example. Can be used to set up an environment across multiple projects. For instance here's one that sets up a flutter environment:
+```
+# Flutter
+-p C:\dev\flutter\bin
+# Android SDK Locations
+-e ANDROID_SDK_ROOT=C:\Users\user1\AppData\Local\Android\Sdk
+-e ANDROID_NDK_ROOT=$ANDROID_SDK_ROOT\ndk\25.0.8775105
+# Android SDK binaries
+-p $ANDROID_SDK_ROOT\tools\bin
+-p $ANDROID_SDK_ROOT\emulator
+```
+
 ## Uses
 ### Running commands
 Bash
@@ -24,7 +38,7 @@ tenv -p C:\dev\hugo hugo
 
 Especially useful for RUST_BACKTRACE on Powershell
 ```powershell
-tenv -e RUST_BACKTRACE=1 cargo -- run
+tenv -e RUST_BACKTRACE=1 "cargo run"
 ```
 ### Shell environment
 Bash

--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ Supports `argfile`s. see [example.tenv](./example.tenv) for an example. Can be u
 -p $ANDROID_SDK_ROOT\emulator
 ```
 
+```bash
+# Spawn bash shell with flutter environment
+tenv @flutter.tenv bash
+```
+```powershell
+# Spawn new powersehll with flutter environment (Need to escape @ in powershell with `)
+tenv `@flutter.tenv powershell
+```
+
 ## Uses
 ### Running commands
 Bash

--- a/example.tenv
+++ b/example.tenv
@@ -1,0 +1,12 @@
+# This is a comment and will be ignored when parsing args
+# Here's JAVA_HOME
+-e JAVA_HOME=/Program Files/AdoptOpenJDK/jdk-8.0.275.1-hotspot
+# You can expand JAVA_HOME like so:
+-e JAVA_BIN=$JAVA_HOME/bin
+# Then you can add it to path
+-p $JAVA_BIN
+# Env Vars not defined in here will no be used, so HOME_DIR will be literally "$HOME"
+-e HOME_DIR=$HOME
+# tilde will be expanded to the home directory
+-e CONFIG_DIR=~/config
+-p ~/bin

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,15 @@ impl CommandArgs {
             .collect();
         println!("argfile args: {args:?}");
         // Get CLI args
-        let args: Self = Self::parse_from(args);
+        let mut args: Self = Self::parse_from(args);
+        // Trim any spaces in env var name
+        args.env_vars.iter_mut().for_each(|(k, _v)| {
+            *k = k.trim().to_string();
+        });
+        // Trim any spaces in path
+        args.path_additions.iter_mut().for_each(|path| {
+            *path = path.trim().to_string();
+        });
         args
     }
     /// Generate new PATH from prepending path additions to existing PATH
@@ -75,7 +83,6 @@ impl CommandArgs {
         self.env_vars
             .clone()
             .into_iter()
-            // .map(|(key, val)| (key.trim().to_string(), val.trim().to_string()))
             .collect()
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub(crate) mod helpers {
     }
     /// Return true if line would be a comment if in an argfile
     pub fn is_argfile_comment(arg: &OsString) -> bool {
-        !arg.to_string_lossy().starts_with('#')
+        arg.to_string_lossy().starts_with('#')
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use tenv::{init_ctrlc_handler, run, CommandArgs};
 
-fn main() {
+fn main() -> Result<(), std::io::Error>{
     // Get CLI args
-    let args = CommandArgs::get_all_args();
+    let args = CommandArgs::get_all_args()?;
     // Initialize control+C handler. If error, just let user know it failed to set handler
     if init_ctrlc_handler().is_err() {
         println!("tenv: could not set ctrl+c handler, so issues may arise if ctrl+c is entered");
@@ -11,4 +11,5 @@ fn main() {
     if let Err(e) = run(&args) {
         println!("Error running command with TEnv: {e}");
     }
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
-use clap::Parser;
 use tenv::{init_ctrlc_handler, run, CommandArgs};
 
 fn main() {
     // Get CLI args
-    let args: CommandArgs = CommandArgs::parse();
+    let args = CommandArgs::get_all_args();
     // Initialize control+C handler. If error, just let user know it failed to set handler
     if init_ctrlc_handler().is_err() {
         println!("tenv: could not set ctrl+c handler, so issues may arise if ctrl+c is entered");


### PR DESCRIPTION
# Argfile support
Adds support for argfiles (closes #3)
Argfiles are just files that contain 1 argument per line and can be used instead of specifying in the command each time. tenv ignores any lines that start with "#", so comments can be added to provide additional information and organization. See `example.tenv` as an example.
## Usage
Spawn a powershell with a specific environment
```
# Powershell requires the back tick to escape the @
tenv `@example.tenv powershell
```

# Fixes
Fixes #9 
Using [dunce](https://docs.rs/dunce/latest/dunce/), we simplify any UNC paths into "normal" paths

Fixes #10 
Using [shellexpand](https://docs.rs/shellexpand/latest/shellexpand/), we expand ~ into the home directory and expand any environment variables *defined in the command arguments*.